### PR TITLE
Make a buildable 2.1.11

### DIFF
--- a/Formula/gnupg2.rb
+++ b/Formula/gnupg2.rb
@@ -2,37 +2,30 @@ require "formula"
 
 class Gnupg2 < Formula
   homepage "https://www.gnupg.org/"
-  url "ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-2.1.0.tar.bz2"
-  mirror "ftp://ftp.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.1.0.tar.bz2"
-  mirror "ftp://mirror.tje.me.uk/pub/mirrors/ftp.gnupg.org/gnupg/gnupg-2.1.0.tar.bz2"
-  sha1 "2fcd0ca6889ef6cb59e3275e8411f8b7778c2f33"
-  revision 1
-
-  patch do
-    url "https://github.com/mtigas/homebrew-gpg21/raw/master/Patches/0001-fix-mac-os-x-build.patch"
-    sha1 "4cd7ec2081646032de291b1f012a647841296f1d"
-  end
-  patch do
-    url "https://github.com/mtigas/homebrew-gpg21/raw/master/Patches/0002-fix-mac-os-x-build.patch"
-    sha1 "6881a4fb198b0399f75e82c73f3c8a8b0e6711a0"
-  end
+  url "ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-2.1.11.tar.bz2"
+  mirror "ftp://ftp.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.1.11.tar.bz2"
+  mirror "ftp://mirror.tje.me.uk/pub/mirrors/ftp.gnupg.org/gnupg/gnupg-2.1.11.tar.bz2"
+  sha1 "4af2032a60ff22e322b1c5b270d6d2228f59a3a3"
+  revision 2
 
   option "8192", "Build with support for private keys of up to 8192 bits"
+  # http://comments.gmane.org/gmane.comp.encryption.gpg.devel/20856
+  option "with-adns", "adns support on osx."
 
+  depends_on "adns"
   depends_on "libgpg-error"
   depends_on "libgcrypt"
   depends_on "libksba"
   depends_on "libassuan"
-  depends_on "pinentry"
+  depends_on "pinentry-mac"
   depends_on "mtigas/gpg21/npth"
-  depends_on "curl" if MacOS.version <= :mavericks
-  depends_on "libusb-compat" => :recommended
+
   depends_on "readline" => :optional
   depends_on "pkg-config" => :build
   depends_on "gnutls" => :optional
 
-  conflicts_with "gpg-agent", :because => "This GnuPG 2.1 includes gpg-agent"
-  conflicts_with "dirmngr", :because => "This GnuPG 2.1 includes dirmngr"
+  conflicts_with "gpg-agent", :because => "GnuPG 2.1 includes gpg-agent"
+  conflicts_with "dirmngr", :because => "GnuPG 2.1 includes dirmngr"
 
   def install
     # Adjust package name to fit our scheme of packaging both gnupg 1.x and
@@ -41,9 +34,9 @@ class Gnupg2 < Formula
       s.gsub! "PACKAGE_NAME='gnupg'", "PACKAGE_NAME='gnupg2'"
       s.gsub! "PACKAGE_TARNAME='gnupg'", "PACKAGE_TARNAME='gnupg2'"
     end
-    inreplace "tools/gpgkey2ssh.c", "gpg --list-keys", "gpg2 --list-keys"
+    #inreplace "tools/gpgkey2ssh.c", "gpg --list-keys", "gpg2 --list-keys"
 
-    inreplace "g10/keygen.c", "max=4096", "max=8192" if build.include? "8192"
+    #inreplace "g10/keygen.c", "max=4096", "max=8192" if build.include? "8192"
 
     (var/"run").mkpath
 
@@ -56,6 +49,7 @@ class Gnupg2 < Formula
       --prefix=#{prefix}
       --sbindir=#{bin}
       --enable-symcryptrun
+      --with-adns
     ]
 
     if build.with? "readline"
@@ -69,6 +63,6 @@ class Gnupg2 < Formula
 
     # Conflicts with a manpage from the 1.x formula, and
     # gpg-zip isn't installed by this formula anyway
-    rm man1/"gpg-zip.1"
+    #rm man1/"gpg-zip.1"
   end
 end


### PR DESCRIPTION
This PR enables one to compile the latest release of gnupg. 
- The 2.1.0 supplied wasn't able to talk to a yubikey and more importantly, seemed to be affected by a 'toggle' bug that wouldn't allow me to select private keys.
- Depend on pinentry-mac which is much more usable (pinentry would drop some of the typed in characters)
- Depend on adns due to a build dependency on [OSX](http://comments.gmane.org/gmane.comp.encryption.gpg.devel/20856
